### PR TITLE
arreglando la galería

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 function setupCarrusel(galeriaClass, prevButtonId, nextButtonId) {
-    const scrollContainer = document.querySelector("galeriaClass");
-    const irbtn = document.getElementById("prevButtonId");
-    const volverbtn = document.getElementById("nextButtonId");
+    const scrollContainer = document.querySelector(galeriaClass);
+    const irbtn = document.getElementById(prevButtonId);
+    const volverbtn = document.getElementById(nextButtonId);
 
     scrollContainer.addEventListener("wheel", (evt) => {
         evt.preventDefault();


### PR DESCRIPTION
El problema estaba en el js, cuando designan el nombre del selector que busca la galería y los botones (en las líneas 2 3 y 4) los escribieron entre comillas entonces busca en el html lo mismo, cosa que no es equivalente en ese archivo.

Solo borré las comillas y ya funciona